### PR TITLE
Add goss_path to allow ability to specify direct OS path

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ options:
         required: true
         description:
             - Test file to validate. Must be on the remote machine.
+    goss_path:
+        required: false
+        description:
+            - change the path location for the goss executable. default is "goss" (no absolute path)
     format:
         required: false
         description:
@@ -82,10 +86,15 @@ examples:
       goss:
         path: "/path/to/file.yml"
 
+    - name: test goss file
+      goss:
+        path: "/path/to/file.yml"
+        goss_path: "/usr/local/bin/goss"
+
     - name: test goss files
       goss:
         path: "{{ item }}"
         format: json
         output_file : /my/output/file-{{ item }}
         with_items: "{{ goss_files }}"
-```
+

--- a/goss.py
+++ b/goss.py
@@ -14,6 +14,10 @@ options:
         required: true
         description:
             - Test file to validate. Must be on the remote machine.
+    goss_path:
+        required: false
+        description:
+            - change the path location for the goss executable. default is "goss" (no absolute path)
     format:
         required: false
         description:
@@ -29,6 +33,11 @@ examples:
       goss:
         path: "/path/to/file.yml"
 
+    - name: test goss file
+      goss:
+        path: "/path/to/file.yml"
+        goss_path: "/usr/local/bin/goss"
+
     - name: test goss files
       goss:
         path: "{{ item }}"
@@ -39,12 +48,12 @@ examples:
 
 
 # launch goss validate command on the file
-def check(module, test_file_path, output_format):
+def check(module, test_file_path, output_format, goss_path):
     cmd = ""
     if output_format is not None:
-        cmd = "goss -g {0} v --format {1}".format(test_file_path, output_format)
+        cmd = "{0} -g {1} v --format {2}".format(goss_path, test_file_path, output_format)
     else:
-        cmd = "goss -g {0} v".format(test_file_path)
+        cmd = "{0} -g {1} v".format(goss_path, test_file_path)
     return module.run_command(cmd)
 
 
@@ -61,6 +70,7 @@ def main():
             path=dict(required=True, type='str'),
             format=dict(required=False, type='str'),
             output_file=dict(required=False, type='str'),
+            goss_path=dict(required=False, default='goss', type='str'),
         ),
         supports_check_mode=False
     )
@@ -68,6 +78,7 @@ def main():
     test_file_path = module.params['path']  # test file path
     output_format = module.params['format']  # goss output format
     output_file_path = module.params['output_file']
+    goss_path = module.params['goss_path']
 
     if test_file_path is None:
         module.fail_json(msg="test file path is null")
@@ -83,7 +94,7 @@ def main():
     if os.path.isdir(test_file_path):
         module.fail_json(msg="Test file must be a file ! : %s" % (test_file_path))
 
-    (rc, out, err) = check(module, test_file_path, output_format)
+    (rc, out, err) = check(module, test_file_path, output_format, goss_path)
 
     if output_file_path is not None:
         output_file_path = os.path.expanduser(output_file_path)


### PR DESCRIPTION
We ran into an issue running this in our environment because we install goss into /usr/local/bin/goss but do not have /usr/local/bin in our root/sudo secure_path, so the task fails:
fatal: [10.1.0.238]: FAILED! => {"changed": false, "cmd": "goss -g /tmp/goss-test.yml  v --format rspecish", "failed": true, "msg": "[Errno 2] No such file or directory", "rc": 2}

The error says “no such file or directory” but my goss test file was present, the issue was a path issue (manually fixing the path and re-running it solved the issue, but I can’t change the path on all my hosts)

So, I’ve included a goss_path parameter to specify the path of the goss executable. This still defaults to “goss” so if you don’t include the parameter. 

I did the following tests in our environment (all successful, except the final one which was expected to fail:

1.	Set “goss_path: /usr/local/bin/goss” and “format: rspecish” in my task
2.	Set  “goss_path: /usr/local/bin/goss” and removed the “format” parameter from my task.
3.	Do not set goss_path in task (so this would default to “goss”), but set “format: rspecish”   
4.	Do not set goss_path AND no format 
5.	Set goss_path to be something garbage, like /usr (this fails, as expected)
