### PR TITLE
Fix module's error message

### DIFF
--- a/goss.py
+++ b/goss.py
@@ -134,7 +134,7 @@ def run_module():
         write_result(output_file_path, out)
 
     if rc is not None and rc != 0:
-        error_msg = 'err : { err } ; out : { out }'
+        error_msg = f'err : { err } ; out : { out }'
         module.fail_json(msg=error_msg)
 
     module.exit_json(stdout=out, changed=False)


### PR DESCRIPTION
Before this change the error message is always :

```
msg: 'err : { err } ; out : { out }'
```

After this change the real command output is printed !