### PR TITLE
correct shebang

### DIFF
--- a/goss.py
+++ b/goss.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python
 # FROM: https://github.com/indusbox/goss-ansible
 '''  Launch goss (https://github.com/aelsabbahy/goss) tests '''
 import os


### PR DESCRIPTION
see https://docs.ansible.com/projects/ansible/latest/dev_guide/testing/sanity/shebang.html

> Most executable files should only use one of the following shebangs:
> ...
> This does not apply to Ansible modules, which should not be executable and must always use
> #!/usr/bin/python.